### PR TITLE
Add registerService method to NsdHelper

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,9 +5,9 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.0.0-rc1'
+        classpath 'com.android.tools.build:gradle:2.2.2'
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.6'
-        classpath 'com.github.dcendents:android-maven-gradle-plugin:1.3'
+        classpath 'com.github.dcendents:android-maven-gradle-plugin:1.5'
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.10-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip

--- a/library/src/main/java/com/rafakob/nsdhelper/NsdHelper.java
+++ b/library/src/main/java/com/rafakob/nsdhelper/NsdHelper.java
@@ -177,7 +177,17 @@ public class NsdHelper implements DiscoveryTimer.OnTimeoutListener {
      * @param serviceType        Service type.
      */
     public void registerService(String desiredServiceName, String serviceType) {
-        int port = findAvaiablePort();
+        registerService(desiredServiceName, serviceType, findAvaiablePort());
+    }
+
+    /**
+     * Register new service with given serivce name, type and port.
+     *
+     * @param desiredServiceName Desired service name. If the name already exists in network it will be change to something like 'AppChat (1)'.
+     * @param serviceType        Service type.
+     * @param port               Service port.
+     */
+    public void registerService(String desiredServiceName, String serviceType, int port) {
         if (port == 0) return;
 
         mRegisteredServiceInfo = new NsdServiceInfo();


### PR DESCRIPTION
Hi Rafał.

Thank you very much for your great NsdHelper. I just used it in my latest app.

In my use case, I ran into an issue when I let the port to be autodetected with findAvaiablePort(). It was something like "cannot bind, already in use". So I created my SocketServer beforehand and added a registerService method to the NsdHelper that takes my computed port as argument. With this very small change everything works as expected for me.

To be able to make the change, I updated the versions of the classpath dependencies to the newest versions.

It would be great, if you would merge the change.

Best regards,
Tobias