### PR TITLE
Fix for strict mode warning when compiling on Android

### DIFF
--- a/library/src/main/java/com/rafakob/nsdhelper/NsdHelper.java
+++ b/library/src/main/java/com/rafakob/nsdhelper/NsdHelper.java
@@ -269,15 +269,13 @@ public class NsdHelper implements DiscoveryTimer.OnTimeoutListener {
         ServerSocket socket;
         try {
             socket = new ServerSocket(0);
-            return socket.getLocalPort();
+            int socketNumber = socket.getLocalPort();
+            socket.close();
+            return socketNumber;
         } catch (IOException e) {
             logError("Couldn't assign port to your service.", 0, "java.net.ServerSocket");
             e.printStackTrace();
             return 0;
-        } finally {
-            if (socket != null) {
-                socket.close();   
-            }
         }
     }
 

--- a/library/src/main/java/com/rafakob/nsdhelper/NsdHelper.java
+++ b/library/src/main/java/com/rafakob/nsdhelper/NsdHelper.java
@@ -274,6 +274,10 @@ public class NsdHelper implements DiscoveryTimer.OnTimeoutListener {
             logError("Couldn't assign port to your service.", 0, "java.net.ServerSocket");
             e.printStackTrace();
             return 0;
+        } finally {
+            if (socket != null) {
+                socket.close();   
+            }
         }
     }
 


### PR DESCRIPTION
When strict mode is enabled it complains about a socket not explicitly being closed.

It was easy to fix, (sorry about the double commit).